### PR TITLE
Add nil defs for better flycheck 

### DIFF
--- a/path.janet
+++ b/path.janet
@@ -35,8 +35,8 @@
 (defmacro- decl-last-sep
   [pre sep]
   ~(def- ,(symbol pre "/last-sep-peg")
-    (peg/compile '{:back (> -1 (+ (* ,sep ($)) :back))
-                   :main (+ :back (constant 0))})))
+     (peg/compile '{:back (> -1 (+ (* ,sep ($)) :back))
+                    :main (+ :back (constant 0))})))
 
 (defmacro- decl-dirname
   [pre]
@@ -161,6 +161,21 @@
 (decl-join "win32" "\\")
 (decl-abspath "win32")
 
+
+#
+# satisfy linters
+#
+
+(def ext nil)
+(def sep nil)
+(def delim nil)
+(def basename nil)
+(def dirname nil)
+(def abspath? nil)
+(def abspath nil)
+(def parts nil)
+(def normalize nil)
+(def join nil)
 #
 # Specialize for current OS
 #

--- a/path.janet
+++ b/path.janet
@@ -163,7 +163,7 @@
 
 
 #
-# satisfy linters
+# satisfy flycheck
 #
 
 (def ext nil)

--- a/path.janet
+++ b/path.janet
@@ -176,6 +176,7 @@
 (def parts nil)
 (def normalize nil)
 (def join nil)
+
 #
 # Specialize for current OS
 #


### PR DESCRIPTION
As discussed in janet-language/help channel. There is one format change by spork/fmt; please let me know if I can leave it, or revert it.